### PR TITLE
Rewrite local auth check to use own IdP

### DIFF
--- a/nagios/README.md
+++ b/nagios/README.md
@@ -26,6 +26,7 @@ services=""
 
 ### Proxy idp authentication test - local
 There are two main scripts (one of them uses SAML, the other uses OIDC) checking the login to SP via the host from which the scripts run and some helper scripts located in folder `proxy_idp_auth_test_script/`
+The main script gradually try to sign in via AAI Playground IdP, MUNI IdP and CESNET IdP.
 
 These scripts are able to cache their last result.
 
@@ -36,8 +37,10 @@ These scripts are able to cache their last result.
     * proxy_idp_auth_test_saml.sh
     * proxy_idp_auth_test_oidc.sh
 * Helper scripts:
+    * proxy_idp_auth_test_script/saml_auth_test_aai.sh
     * proxy_idp_auth_test_script/saml_auth_test_cesnet.sh
     * proxy_idp_auth_test_script/saml_auth_test_muni.sh
+    * proxy_idp_auth_test_script/oidc_auth_test_aai.sh
     * proxy_idp_auth_test_script/oidc_auth_test_cesnet.sh
     * proxy_idp_auth_test_script/oidc_auth_test_muni.sh
 * Requirements:
@@ -50,17 +53,21 @@ These scripts are able to cache their last result.
             <pre>
             # The urls of tested SP
             # For example: https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authentication=muni
+            AAI_SAML_TEST_SITE=""          # Needed only for SAML
             MUNI_SAML_TEST_SITE=""          # Needed only for SAML
             CESNET_SAML_TEST_SITE=""        # Needed only for SAML
+            AAI_OIDC_TEST_SITE=""          # Needed only for OIDC
             MUNI_OIDC_TEST_SITE=""          # Needed only for OIDC
             CESNET_OIDC_TEST_SITE=""        # Needed only for OIDC
 
             # The url of logins form of used IdP
             # For example: https://idp2.ics.muni.cz/idp/Authn/UserPassword
+            AAI_LOGIN_SITE=""
             MUNI_LOGIN_SITE=""
             CESNET_LOGIN_SITE=""
 
             # Fill in logins
+            AAI_LOGIN=""
             MUNI_LOGIN=""
             CESNET_LOGIN=""
 

--- a/nagios/proxy_idp_auth_test_config.sh
+++ b/nagios/proxy_idp_auth_test_config.sh
@@ -1,20 +1,25 @@
 # The urls of tested SP
 # For example: https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authentication=muni
+AAI_SAML_TEST_SITE=""
+AAI_OIDC_TEST_SITE=""
 MUNI_SAML_TEST_SITE=""
-CESNET_SAML_TEST_SITE=""
 MUNI_OIDC_TEST_SITE=""
+CESNET_SAML_TEST_SITE=""
 CESNET_OIDC_TEST_SITE=""
 
 # The url of logins form of used IdP
 # For example: https://idp2.ics.muni.cz/idp/Authn/UserPassword
+AAI_LOGIN_SITE=""
 MUNI_LOGIN_SITE=""
 CESNET_LOGIN_SITE=""
 
 # Fill in logins
+AAI_LOGIN=""
 MUNI_LOGIN=""
 CESNET_LOGIN=""
 
 # Fill in passwords as string
+AAI_PASSWORD=""
 MUNI_PASSWORD=""
 CESNET_PASSWORD=""
 

--- a/nagios/proxy_idp_auth_test_oidc.sh
+++ b/nagios/proxy_idp_auth_test_oidc.sh
@@ -30,9 +30,41 @@ WARNING_TIME=${OIDC_WARNING_TIME}
 
 SCRIPT_DIR="${DIR}/proxy_idp_auth_test_script"
 
+AAI_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_aai.sh ${AAI_OIDC_TEST_SITE} ${AAI_LOGIN_SITE} ${AAI_LOGIN} ${AAI_PASSWORD} ${PROXY_DOMAIN_NAME}"
 MUNI_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_muni.sh ${MUNI_OIDC_TEST_SITE} ${MUNI_LOGIN_SITE} ${MUNI_LOGIN} ${MUNI_PASSWORD} ${PROXY_DOMAIN_NAME}"
 CESNET_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_cesnet.sh ${CESNET_OIDC_TEST_SITE} ${CESNET_LOGIN_SITE} ${CESNET_LOGIN} ${CESNET_PASSWORD} ${PROXY_DOMAIN_NAME}"
 
+# Test sign in with AAI Playground IdP
+START_TIME=$(date +%s%N)
+AAI_RESULT=$(timeout ${TIMEOUT_TIME} ${AAI_LOGIN_CMD})
+AAI_RC=$?
+END_TIME=$(date +%s%N)
+
+if [ ${AAI_RC} -gt 2 ]; then
+  AAI_RC=2
+  AAI_RESULT="Login with AAI account timeouted after ${TIMEOUT_TIME}s!"
+fi
+AAI_TOTAL_TIME=$(expr ${END_TIME} - ${START_TIME})
+AAI_LOGIN_TIME=$(echo "scale=4;${AAI_TOTAL_TIME} / 1000000000" | bc -l)
+
+# Signing in with AAI account was successful. Returning OK.
+if [ ${AAI_RC} -eq 0 ]; then
+    if [ ${AAI_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ];then
+        STATUS=1
+        STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
+    else
+        STATUS=0
+        STATUS_TXT="Successful login!"
+    fi
+
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=0|cesnet_login_time=0 ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - Not tried; CESNET STATUS - Not tried]"
+    echo ${RESULT}
+    echo ${RESULT} > ${DIR}/proxy_idp_auth_test_oidc.cache
+    exit 0
+fi
+
+
+# Test sign in with MUNI IdP
 START_TIME=$(date +%s%N)
 MUNI_RESULT=$(timeout ${TIMEOUT_TIME} ${MUNI_LOGIN_CMD})
 MUNI_RC=$?
@@ -44,6 +76,24 @@ fi
 MUNI_TOTAL_TIME=$(expr ${END_TIME} - ${START_TIME})
 MUNI_LOGIN_TIME=$(echo "scale=4;${MUNI_TOTAL_TIME} / 1000000000" | bc -l)
 
+# Signing in with MUNI account was successful. Returning OK.
+if [ ${MUNI_RC} -eq 0 ]; then
+    if [ ${MUNI_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ];then
+        STATUS=1
+        STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
+    else
+        STATUS=0
+        STATUS_TXT="Successful login!"
+    fi
+
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=0 ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - Not tried]"
+    echo ${RESULT}
+    echo ${RESULT} > ${DIR}/proxy_idp_auth_test_oidc.cache
+    exit 0
+fi
+
+
+# Test sign in with CESNET IdP
 START_TIME=$(date +%s%N)
 CESNET_RESULT=$(timeout ${TIMEOUT_TIME} ${CESNET_LOGIN_CMD})
 CESNET_RC=$?
@@ -57,20 +107,19 @@ fi
 CESNET_TOTAL_TIME=$(expr ${END_TIME} - ${START_TIME})
 CESNET_LOGIN_TIME=$(echo "scale=4;${CESNET_TOTAL_TIME} / 1000000000" | bc -l)
 
-if [[ ${MUNI_RC} -eq 0 || ${CESNET_RC} -eq 0 ]]; then
-  if [[ ${MUNI_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) && ${CESNET_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ]];then
-    STATUS=1
-    STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
-  else
-    STATUS=0
-    STATUS_TXT="Successful login!"
-  fi
+# Signing in with CESNET account was successful. Returning OK.
+if [ ${CESNET_RC} -eq 0 ]; then
+    if [ ${CESNET_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ];then
+        STATUS=1
+        STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
+    else
+        STATUS=0
+        STATUS_TXT="Successful login!"
+    fi
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=${CESNET_LOGIN_TIME} ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - ${CESNET_RESULT}(${CESNET_LOGIN_TIME}s)]"
 else
-  STATUS=2
-  STATUS_TXT="Unsuccessful login!"
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=${CESNET_LOGIN_TIME} ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - ${CESNET_RESULT}(${CESNET_LOGIN_TIME}s)]"
 fi
-
-RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=${CESNET_LOGIN_TIME} ${STATUS_TXT} [MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - ${CESNET_RESULT}(${CESNET_LOGIN_TIME}s)]"
 
 echo ${RESULT}
 echo ${RESULT} > ${DIR}/proxy_idp_auth_test_oidc.cache

--- a/nagios/proxy_idp_auth_test_saml.sh
+++ b/nagios/proxy_idp_auth_test_saml.sh
@@ -30,9 +30,40 @@ WARNING_TIME=${SAML_WARNING_TIME}
 
 SCRIPT_DIR="${DIR}/proxy_idp_auth_test_script"
 
+AAI_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_aai.sh ${AAI_SAML_TEST_SITE} ${AAI_LOGIN_SITE} ${AAI_LOGIN} ${AAI_PASSWORD} ${PROXY_DOMAIN_NAME}"
 MUNI_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_muni.sh ${MUNI_SAML_TEST_SITE} ${MUNI_LOGIN_SITE} ${MUNI_LOGIN} ${MUNI_PASSWORD} ${PROXY_DOMAIN_NAME}"
 CESNET_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_cesnet.sh ${CESNET_SAML_TEST_SITE} ${CESNET_LOGIN_SITE} ${CESNET_LOGIN} ${CESNET_PASSWORD} ${PROXY_DOMAIN_NAME}"
 
+# Test sign in with AAI Playground IdP
+START_TIME=$(date +%s%N)
+AAI_RESULT=$(timeout ${TIMEOUT_TIME} ${AAI_LOGIN_CMD})
+AAI_RC=$?
+END_TIME=$(date +%s%N)
+
+if [ ${AAI_RC} -gt 2 ]; then
+  AAI_RC=2
+  AAI_RESULT="Login with AAI account timeouted after ${TIMEOUT_TIME}s!"
+fi
+AAI_TOTAL_TIME=$(expr ${END_TIME} - ${START_TIME})
+AAI_LOGIN_TIME=$(echo "scale=4;${AAI_TOTAL_TIME} / 1000000000" | bc -l)
+
+# Signing in with AAI account was successful. Returning OK.
+if [ ${AAI_RC} -eq 0 ]; then
+    if [ ${AAI_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ];then
+        STATUS=1
+        STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
+    else
+        STATUS=0
+        STATUS_TXT="Successful login!"
+    fi
+
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=0|cesnet_login_time=0 ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - Not tried; CESNET STATUS - Not tried]"
+    echo ${RESULT}
+    echo ${RESULT} > ${DIR}/proxy_idp_auth_test_saml.cache
+    exit 0
+fi
+
+# Test sign in with MUNI IdP
 START_TIME=$(date +%s%N)
 MUNI_RESULT=$(timeout ${TIMEOUT_TIME} ${MUNI_LOGIN_CMD})
 MUNI_RC=$?
@@ -44,6 +75,24 @@ fi
 MUNI_TOTAL_TIME=$(expr ${END_TIME} - ${START_TIME})
 MUNI_LOGIN_TIME=$(echo "scale=4;${MUNI_TOTAL_TIME} / 1000000000" | bc -l)
 
+# Signing in with MUNI account was successful. Returning OK.
+if [ ${MUNI_RC} -eq 0 ]; then
+    if [ ${MUNI_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ];then
+        STATUS=1
+        STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
+    else
+        STATUS=0
+        STATUS_TXT="Successful login!"
+    fi
+
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=0 ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - Not tried]"
+    echo ${RESULT}
+    echo ${RESULT} > ${DIR}/proxy_idp_auth_test_saml.cache
+    exit 0
+fi
+
+
+# Test sign in with CESNET IdP
 START_TIME=$(date +%s%N)
 CESNET_RESULT=$(timeout ${TIMEOUT_TIME} ${CESNET_LOGIN_CMD})
 CESNET_RC=$?
@@ -57,20 +106,20 @@ fi
 CESNET_TOTAL_TIME=$(expr ${END_TIME} - ${START_TIME})
 CESNET_LOGIN_TIME=$(echo "scale=4;${CESNET_TOTAL_TIME} / 1000000000" | bc -l)
 
-if [[ ${MUNI_RC} -eq 0 || ${CESNET_RC} -eq 0 ]]; then
-  if [[ ${MUNI_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) && ${CESNET_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ]];then
-    STATUS=1
-    STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
-  else
-    STATUS=0
-    STATUS_TXT="Successful login!"
-  fi
-else
-  STATUS=2
-  STATUS_TXT="Unsuccessful login!"
-fi
 
-RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=${CESNET_LOGIN_TIME} ${STATUS_TXT} [MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - ${CESNET_RESULT}(${CESNET_LOGIN_TIME}s)]"
+# Signing in with CESNET account was successful. Returning OK.
+if [ ${CESNET_RC} -eq 0 ]; then
+    if [ ${CESNET_TOTAL_TIME} -gt $(( WARNING_TIME * 1000000000 )) ];then
+        STATUS=1
+        STATUS_TXT="Successful login, but was too long(More than ${WARNING_TIME}s)!"
+    else
+        STATUS=0
+        STATUS_TXT="Successful login!"
+    fi
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=${CESNET_LOGIN_TIME} ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - ${CESNET_RESULT}(${CESNET_LOGIN_TIME}s)]"
+else
+    RESULT="${STATUS} ${BASENAME}-${INSTANCE_NAME} aai_login_time=${AAI_LOGIN_TIME}|muni_login_time=${MUNI_LOGIN_TIME}|cesnet_login_time=${CESNET_LOGIN_TIME} ${STATUS_TXT} [AAI STATUS - ${AAI_RESULT}(${AAI_LOGIN_TIME}s);MUNI STATUS - ${MUNI_RESULT}(${MUNI_LOGIN_TIME}s); CESNET STATUS - ${CESNET_RESULT}(${CESNET_LOGIN_TIME}s)]"
+fi
 
 echo ${RESULT}
 echo ${RESULT} > ${DIR}/proxy_idp_auth_test_saml.cache

--- a/nagios/proxy_idp_auth_test_script/oidc_auth_test_aai.sh
+++ b/nagios/proxy_idp_auth_test_script/oidc_auth_test_aai.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# This script is used make a full roundtrip login test to OIDC SP via MUNI account
+# Exit statuses indicate problem and are suitable for usage in Nagios.
+# @author Pavel Vyskocil <Pavel.Vyskocil@cesnet.cz>
+
+end()
+{
+  LOGIN_STATUS=$1
+  LOGIN_STATUS_TXT=$2
+
+  # Clean up
+  rm -f "${COOKIE_FILE}"
+
+  echo "${LOGIN_STATUS_TXT}"
+  exit "${LOGIN_STATUS}"
+}
+
+BASENAME=$(basename $0)
+
+## Get host IP
+IP=($(hostname -I))
+IP="78.128.216.77"
+
+
+TEST_SITE=$1
+LOGIN_SITE=$2
+LOGIN=$3
+PASSWORD=$4
+DOMAIN_NAME=$5
+
+COOKIE_FILE=$(mktemp /tmp/"${BASENAME}".XXXXXX) || exit 3
+
+# REQUEST #1: fetch URL for authentication page
+HTML=$(curl -L -sS -c "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' --resolve ${DOMAIN_NAME}':443:'${IP} ${TEST_SITE}) || (end 2 "Failed to fetch URL: ${TEST_SITE}")
+
+# Parse HTML to get the URL where to POST LOGIN (written out by curl itself above)
+AUTH_URL=$(echo ${HTML} | sed -e 's/.*LAST_URL:\(.*\)$/\1/')
+AUTH_STATE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*AuthState[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+
+# We should be redirected
+if [[ ${AUTH_URL} == "${TEST_SITE}" ]]; then
+    end 2 "No redirection to: ${LOGIN_SITE}."
+fi
+
+# REQUEST #2: log in
+HTML=$(curl -L -s -c "${COOKIE_FILE}" -b "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' \
+-d "username=$LOGIN" -d  "password=$PASSWORD" --data-urlencode "AuthState=${AUTH_STATE}" --resolve ${DOMAIN_NAME}':443:'${IP} ${AUTH_URL}) || (end 2 "Failed to fetch URL: ${AUTH_URL}")
+
+LAST_URL=$(echo ${HTML} | sed -e 's/.*LAST_URL:\(.*\)$/\1/')
+
+# We do not support JS, so parse HTML for SAML endpoint and response
+PROXY_ENDPOINT=$(echo ${HTML} | sed -e 's/.*form[^>]*action=[\"'\'']\([^\"'\'']*\)[\"'\''].*method[^>].*/\1/' | php -R 'echo HTML_entity_decode($argn);')
+PROXY_RESPONSE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*SAMLResponse[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+
+if [[ ${PROXY_ENDPOINT} == "?" ]]; then
+    end 2 "Invalid credentials."
+fi
+
+# REQUEST #3: post the SAMLResponse to proxy
+HTML=$(curl -L -s -c "${COOKIE_FILE}" -b "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' \
+  --data-urlencode "SAMLResponse=${PROXY_RESPONSE}" --resolve "${DOMAIN_NAME}"':443:'${IP} "${PROXY_ENDPOINT}") || (end 2 "Failed to fetch URL: ${PROXY_ENDPOINT}" )
+
+if [[ $HTML == *errorreport.php* ]]; then
+    MSG=$(echo ${HTML} | sed -e 's/.*<h1>.*<\/i>\s\(.*\)\s<\/h1>.*id="content">\s<p>\s\(.*\)<a.*moreInfo.*/\1 - \2/g')
+    end 2 "Got error: ${MSG} "
+fi
+
+# We do not support JS, so parse HTML for SAML endpoint and response
+SP_ENDPOINT=$(echo ${HTML} | sed -e 's/.*form[^>]*action=[\"'\'']\([^\"'\'']*\)[\"'\''].*method[^>].*/\1/')
+SP_RESPONSE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*SAMLResponse[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+SP_RELAY_STATE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*RelayState[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+
+# REQUEST #4: post the SAMLResponse to SP
+HTML=$(curl -L -s -c "${COOKIE_FILE}" -b "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' \
+  --data-urlencode "SAMLResponse=${SP_RESPONSE}" --data-urlencode "RelayState=${SP_RELAY_STATE}" --resolve "${DOMAIN_NAME}"':443:'${IP} "${SP_ENDPOINT}") || (end 2 "Failed to fetch URL: ${SP_ENDPOINT}" )
+
+LAST_URL=$(echo ${HTML} | sed -e 's/.*LAST_URL:\(.*\)$/\1/')
+
+# OIDC adds some params to the "testSite" URL so we need to compare like this
+MATCH=$(echo $LAST_URL | sed -e 's/\(https.*aai-playground.*code=.*state=.*\)$/OK/')
+if [[ $MATCH == 'OK' ]]; then
+    RESULT=$(echo ${HTML} | sed -e 's/.*<body>\sResult-\(.*\)\s<\/body.*$/\1/')
+    if [[ $RESULT == "OK" ]]; then
+        end 0 "Successful login"
+    else
+        end 2 "Bad result: ${RESULT}."
+    fi
+else
+    end 2 "Not redirected back to: ${TEST_SITE}&code=...&state=...."
+fi

--- a/nagios/proxy_idp_auth_test_script/saml_auth_test_aai.sh
+++ b/nagios/proxy_idp_auth_test_script/saml_auth_test_aai.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# This script is used make a full roundtrip login test to SAML SP via OWN Identity provider
+# Exit statuses indicate problem and are suitable for usage in Nagios.
+# @author Pavel Vyskocil <Pavel.Vyskocil@cesnet.cz>
+
+end()
+{
+  LOGIN_STATUS=$1
+  LOGIN_STATUS_TXT=$2
+
+  # Clean up
+  rm -f "${COOKIE_FILE}"
+
+  echo "${LOGIN_STATUS_TXT}"
+  exit "${LOGIN_STATUS}"
+}
+
+BASENAME=$(basename $0)
+
+## Get host IP
+IP=($(hostname -I))
+IP="78.128.216.77"
+
+TEST_SITE=$1
+LOGIN_SITE=$2
+LOGIN=$3
+PASSWORD=$4
+DOMAIN_NAME=$5
+
+COOKIE_FILE=$(mktemp /tmp/"${BASENAME}".XXXXXX) || exit 3
+
+# REQUEST #1: fetch URL for authentication page
+HTML=$(curl -L -sS -c "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' --resolve ${DOMAIN_NAME}':443:'${IP} ${TEST_SITE}) || (end 2 "Failed to fetch URL: ${TEST_SITE}")
+
+# Parse HTML to get the URL where to POST LOGIN (written out by curl itself above)
+AUTH_URL=$(echo ${HTML} | sed -e 's/.*LAST_URL:\(.*\)$/\1/')
+AUTH_STATE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*AuthState[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+
+# We should be redirected
+if [[ ${AUTH_URL} == "${TEST_SITE}" ]]; then
+    end 2 "No redirection to: ${LOGIN_SITE}."
+fi
+
+# REQUEST #2: log in
+HTML=$(curl -L -s -c "${COOKIE_FILE}" -b "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' \
+-d "username=$LOGIN" -d  "password=$PASSWORD" --data-urlencode "AuthState=${AUTH_STATE}" --resolve ${DOMAIN_NAME}':443:'${IP} ${AUTH_URL}) || (end 2 "Failed to fetch URL: ${AUTH_URL}")
+
+LAST_URL=$(echo ${HTML} | sed -e 's/.*LAST_URL:\(.*\)$/\1/')
+
+# We do not support JS, so parse HTML for SAML endpoint and response
+PROXY_ENDPOINT=$(echo ${HTML} | sed -e 's/.*form[^>]*action=[\"'\'']\([^\"'\'']*\)[\"'\''].*method[^>].*/\1/' | php -R 'echo HTML_entity_decode($argn);')
+PROXY_RESPONSE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*SAMLResponse[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+
+if [[ ${PROXY_ENDPOINT} == "?" ]]; then
+    end 2 "Invalid credentials."
+fi
+
+# REQUEST #3: post the SAMLResponse to proxy
+HTML=$(curl -L -s -c "${COOKIE_FILE}" -b "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' \
+  --data-urlencode "SAMLResponse=${PROXY_RESPONSE}" --resolve "${DOMAIN_NAME}"':443:'${IP} "${PROXY_ENDPOINT}") || (end 2 "Failed to fetch URL: ${PROXY_ENDPOINT}" )
+
+if [[ $HTML == *errorreport.php* ]]; then
+    MSG=$(echo ${HTML} | sed -e 's/.*<h1>.*<\/i>\s\(.*\)\s<\/h1>.*id="content">\s<p>\s\(.*\)<a.*moreInfo.*/\1 - \2/g')
+    end 2 "Got error: ${MSG} "
+fi
+
+# We do not support JS, so parse HTML for SAML endpoint and response
+SP_ENDPOINT=$(echo ${HTML} | sed -e 's/.*form[^>]*action=[\"'\'']\([^\"'\'']*\)[\"'\''].*method[^>].*/\1/')
+SP_RESPONSE=$(echo ${HTML} | sed -e 's/.*hidden[^>]*SAMLResponse[^>]*value=[\"'\'']\([^\"'\'']*\)[\"'\''].*/\1/')
+
+# REQUEST #4: post the SAMLResponse to SP
+HTML=$(curl -L -s -c "${COOKIE_FILE}" -b "${COOKIE_FILE}" -w 'LAST_URL:%{url_effective}' \
+  --data-urlencode "SAMLResponse=${SP_RESPONSE}" --resolve "${DOMAIN_NAME}"':443:'${IP} "${SP_ENDPOINT}") || (end 2 "Failed to fetch URL: ${SP_ENDPOINT}" )
+
+LAST_URL=$(echo ${HTML} | sed -e 's/.*LAST_URL:\(.*\)$/\1/')
+
+if [[ ${LAST_URL} ==  "${TEST_SITE}" ]]; then
+    RESULT=$(echo ${HTML} | sed -e 's/.*<body>\s*Result-\(.*\)<.*$/\1/')
+    if [[ $RESULT == "OK " ]]; then
+        end 0 "Successful login"
+    else
+        end 2 "Bad result: ${RESULT}."
+    fi
+else
+    end 2 "Not redirected back to: ${TEST_SITE}."
+fi


### PR DESCRIPTION
* Rewrote local auth check to use our own IdP running on AAI Playground
* Changed the evaluation condition if Proxy is OK or not:
** Firstly it checks if signing in via AAI Playground IdP is OK and returns OK.
** If not, checks if signing in via MUNI IdP is OK and returns OK
** If not, checks if signing in via CESNET IdP is OK and returns OK
** If all checks failed, returns ERROR