### PR TITLE
Changes in proxy_idp_auth_test_active_saml/oidc.sh

### DIFF
--- a/nagios/README.md
+++ b/nagios/README.md
@@ -139,22 +139,15 @@ The main script gradually try to sign in via AAI Playground IdP, MUNI IdP and CE
     * proxy_idp_auth_test_script/saml_auth_test_muni_active.sh
     * proxy_idp_auth_test_script/oidc_auth_test_cesnet_active.sh
     * proxy_idp_auth_test_script/oidc_auth_test_muni_active.sh
+* Requirements:
+    * Configuration file - Example configuration file: `proxy_idp_auth_test_active_config.sh`
 * How to run these scripts:
     * Params:
-        * 1 - The url of tested SP via MU account
-        * 2 - The url of login form of MU IdP
-        * 3 - MU Login
-        * 4 - MU Password
-        * 5 - The url of tested SP via CESNET account
-        * 6 - The url of login form of CESNET IdP
-        * 7 - CESNET Login
-        * 8 - CESNET Password
-        * 9 - Roundtrip time (in seconds) - The standard login time. After this time the return value can be changed to WARNING state
-        * 10 - Timeout time (in seconds) - After this time the helper script timeouts
+        * 1 - Path to the configuration
     * Examples:
         <pre>
-        ./proxy_idp_auth_test_active_saml.sh "https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authenticate=muni" "https://idp2.ics.muni.cz/idp/Authn/UserPassword" "login" "passwd" "https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authenticate=cesnet" "https://idp2.ics.muni.cz/idp/Authn/UserPassword" "login" "passwd" 10 40
-        ./proxy_idp_auth_test_active_oidc.sh "https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authenticate=muni" "https://idp2.ics.muni.cz/idp/Authn/UserPassword" "login" "passwd" "https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authenticate=cesnet" "https://idp2.ics.muni.cz/idp/Authn/UserPassword" "login" "passwd" 15 40
+        ./proxy_idp_auth_test_active_saml.sh "proxy_idp_auth_test_active_config.sh"
+        ./proxy_idp_auth_test_active_oidc.sh "proxy_idp_auth_test_active_config.sh"
         </pre>
 
 ### mariadb_replication_check.sh

--- a/nagios/proxy_idp_auth_test_active_config.sh
+++ b/nagios/proxy_idp_auth_test_active_config.sh
@@ -1,0 +1,31 @@
+# The urls of tested SP
+# For example: https://aai-playground.ics.muni.cz/simplesaml/nagios_check.php?proxy_idp=cesnet&authentication=muni
+AAI_SAML_TEST_SITE=""
+AAI_OIDC_TEST_SITE=""
+MUNI_SAML_TEST_SITE=""
+MUNI_OIDC_TEST_SITE=""
+CESNET_SAML_TEST_SITE=""
+CESNET_OIDC_TEST_SITE=""
+
+# The url of logins form of used IdP
+# For example: https://idp2.ics.muni.cz/idp/Authn/UserPassword
+AAI_LOGIN_SITE=""
+MUNI_LOGIN_SITE=""
+CESNET_LOGIN_SITE=""
+
+# Fill in logins
+AAI_LOGIN=""
+MUNI_LOGIN=""
+CESNET_LOGIN=""
+
+# Fill in passwords as string
+AAI_PASSWORD=""
+MUNI_PASSWORD=""
+CESNET_PASSWORD=""
+
+
+# How long is normal for total roundtrip (seconds)
+WARNING_TIME=10
+
+# Timeout time
+TIMEOUT_TIME=40

--- a/nagios/proxy_idp_auth_test_active_oidc.sh
+++ b/nagios/proxy_idp_auth_test_active_oidc.sh
@@ -4,29 +4,32 @@
 # Exit statuses indicate problem and are suitable for usage in Nagios.
 # @author Pavel Vyskocil <Pavel.Vyskocil@cesnet.cz>
 
+FILENAME=$1
+
+if [ "$#" -ne 1 ]; then
+    echo "You must enter exactly 1 command line arguments!"
+    echo "The first param must be the file with the configuration!"
+    exit 127
+fi
+
+if [[ ! -f ${FILENAME} ]]; then
+    echo "File ${FILENAME} doesn't exist."
+    echo "The first param must be the file with the configuration!"
+    exit 127
+fi
+
+source "${FILENAME}"
+
+
 DIR="${0%/*}"
 SCRIPT_DIR="${DIR}/proxy_idp_auth_test_script"
 
 BASENAME=$(basename "$0")
 
-AAI_TEST_SITE=${1}
-AAI_LOGIN_SITE=${2}
-AAI_LOGIN=${3}
-AAI_PASSWORD=${4}
-MUNI_TEST_SITE=${5}
-MUNI_LOGIN_SITE=${6}
-MUNI_LOGIN=${7}
-MUNI_PASSWORD=${8}
-CESNET_TEST_SITE=${9}
-CESNET_LOGIN_SITE=${10}
-CESNET_LOGIN=${11}
-CESNET_PASSWORD=${12}
-WARNING_TIME=${13}
-TIMEOUT_TIME=${14}
 
-AAI_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_aai_active.sh ${AAI_TEST_SITE} ${AAI_LOGIN_SITE} ${AAI_LOGIN} ${AAI_PASSWORD}"
-MUNI_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_muni_active.sh ${MUNI_TEST_SITE} ${MUNI_LOGIN_SITE} ${MUNI_LOGIN} ${MUNI_PASSWORD}"
-CESNET_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_cesnet_active.sh ${CESNET_TEST_SITE} ${CESNET_LOGIN_SITE} ${CESNET_LOGIN} ${CESNET_PASSWORD}"
+AAI_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_aai_active.sh ${AAI_OIDC_TEST_SITE} ${AAI_LOGIN_SITE} ${AAI_LOGIN} ${AAI_PASSWORD}"
+MUNI_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_muni_active.sh ${MUNI_OIDC_TEST_SITE} ${MUNI_LOGIN_SITE} ${MUNI_LOGIN} ${MUNI_PASSWORD}"
+CESNET_LOGIN_CMD="$SCRIPT_DIR/oidc_auth_test_cesnet_active.sh ${CESNET_OIDC_TEST_SITE} ${CESNET_LOGIN_SITE} ${CESNET_LOGIN} ${CESNET_PASSWORD}"
 
 
 # Test sign in with AAI Playground IdP

--- a/nagios/proxy_idp_auth_test_active_saml.sh
+++ b/nagios/proxy_idp_auth_test_active_saml.sh
@@ -4,30 +4,30 @@
 # Exit statuses indicate problem and are suitable for usage in Nagios.
 # @author Pavel Vyskocil <Pavel.Vyskocil@cesnet.cz>
 
+FILENAME=$1
+
+if [ "$#" -ne 1 ]; then
+    echo "You must enter exactly 1 command line arguments!"
+    echo "The first param must be the file with the configuration!"
+    exit 127
+fi
+
+if [[ ! -f ${FILENAME} ]]; then
+    echo "File ${FILENAME} doesn't exist."
+    echo "The first param must be the file with the configuration!"
+    exit 127
+fi
+
+source "${FILENAME}"
+
 DIR="${0%/*}"
 SCRIPT_DIR="${DIR}/proxy_idp_auth_test_script"
 
 BASENAME=$(basename "$0")
 
-AAI_TEST_SITE=${1}
-AAI_LOGIN_SITE=${2}
-AAI_LOGIN=${3}
-AAI_PASSWORD=${4}
-MUNI_TEST_SITE=${5}
-MUNI_LOGIN_SITE=${6}
-MUNI_LOGIN=${7}
-MUNI_PASSWORD=${8}
-CESNET_TEST_SITE=${9}
-CESNET_LOGIN_SITE=${10}
-CESNET_LOGIN=${11}
-CESNET_PASSWORD=${12}
-WARNING_TIME=${13}
-TIMEOUT_TIME=${14}
-
-AAI_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_aai_active.sh ${AAI_TEST_SITE} ${AAI_LOGIN_SITE} ${AAI_LOGIN} ${AAI_PASSWORD}"
-MUNI_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_muni_active.sh ${MUNI_TEST_SITE} ${MUNI_LOGIN_SITE} ${MUNI_LOGIN} ${MUNI_PASSWORD}"
-CESNET_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_cesnet_active.sh ${CESNET_TEST_SITE} ${CESNET_LOGIN_SITE} ${CESNET_LOGIN} ${CESNET_PASSWORD}"
-
+AAI_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_aai_active.sh ${AAI_SAML_TEST_SITE} ${AAI_LOGIN_SITE} ${AAI_LOGIN} ${AAI_PASSWORD}"
+MUNI_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_muni_active.sh ${MUNI_SAML_TEST_SITE} ${MUNI_LOGIN_SITE} ${MUNI_LOGIN} ${MUNI_PASSWORD}"
+CESNET_LOGIN_CMD="$SCRIPT_DIR/saml_auth_test_cesnet_active.sh ${CESNET_SAML_TEST_SITE} ${CESNET_LOGIN_SITE} ${CESNET_LOGIN} ${CESNET_PASSWORD}"
 
 # Test sign in with AAI Playground IdP
 START_TIME=$(date +%s%N)


### PR DESCRIPTION
* Use configuration file instead of command line args
* Only one argument is passed - the path to the configuration file